### PR TITLE
45 - Find any existing Payment Submissions for the same Consent

### DIFF
--- a/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_6/domesticpayments/DomesticPaymentsApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_6/domesticpayments/DomesticPaymentsApiController.java
@@ -21,8 +21,7 @@
 package com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.v3_1_6.domesticpayments;
 
 import com.forgerock.securebanking.openbanking.uk.rs.persistence.repository.payments.DomesticPaymentSubmissionRepository;
-import com.forgerock.securebanking.openbanking.uk.rs.validator.IdempotencyValidator;
-import com.forgerock.securebanking.openbanking.uk.rs.validator.OBRisk1Validator;
+import com.forgerock.securebanking.openbanking.uk.rs.validator.PaymentSubmissionValidator;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
 
@@ -32,9 +31,8 @@ public class DomesticPaymentsApiController
         extends com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.v3_1_5.domesticpayments.DomesticPaymentsApiController
         implements DomesticPaymentsApi {
 
-    public DomesticPaymentsApiController(DomesticPaymentSubmissionRepository domesticPaymentSubmissionRepository,
-                                         IdempotencyValidator idempotencyValidator,
-                                         OBRisk1Validator riskValidator) {
-        super(domesticPaymentSubmissionRepository, idempotencyValidator, riskValidator);
+    public DomesticPaymentsApiController(DomesticPaymentSubmissionRepository paymentSubmissionRepository,
+                                         PaymentSubmissionValidator paymentSubmissionValidator) {
+        super(paymentSubmissionRepository, paymentSubmissionValidator);
     }
 }

--- a/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/persistence/document/payment/FRDomesticPaymentSubmission.java
+++ b/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/persistence/document/payment/FRDomesticPaymentSubmission.java
@@ -35,7 +35,7 @@ public class FRDomesticPaymentSubmission implements PaymentSubmission {
     @Indexed
     private String id;
 
-    private FRWriteDomestic domesticPayment;
+    private FRWriteDomestic payment;
 
     private FRSubmissionStatus status;
 
@@ -47,4 +47,9 @@ public class FRDomesticPaymentSubmission implements PaymentSubmission {
     private String idempotencyKey;
 
     private OBVersion obVersion;
+
+    @Override
+    public String getConsentId() {
+        return payment.getData().getConsentId();
+    }
 }

--- a/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/persistence/document/payment/FRDomesticScheduledPaymentSubmission.java
+++ b/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/persistence/document/payment/FRDomesticScheduledPaymentSubmission.java
@@ -34,7 +34,7 @@ public class FRDomesticScheduledPaymentSubmission implements PaymentSubmission {
     @Indexed
     private String id;
 
-    private FRWriteDomesticScheduled domesticScheduledPayment;
+    private FRWriteDomesticScheduled scheduledPayment;
 
     private FRSubmissionStatus status;
 
@@ -46,4 +46,9 @@ public class FRDomesticScheduledPaymentSubmission implements PaymentSubmission {
     private String idempotencyKey;
 
     private OBVersion obVersion;
+
+    @Override
+    public String getConsentId() {
+        return scheduledPayment.getData().getConsentId();
+    }
 }

--- a/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/persistence/document/payment/FRDomesticStandingOrderPaymentSubmission.java
+++ b/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/persistence/document/payment/FRDomesticStandingOrderPaymentSubmission.java
@@ -34,7 +34,7 @@ public class FRDomesticStandingOrderPaymentSubmission implements PaymentSubmissi
     @Indexed
     private String id;
 
-    private FRWriteDomesticStandingOrder domesticStandingOrder;
+    private FRWriteDomesticStandingOrder standingOrder;
 
     private FRSubmissionStatus status;
 
@@ -46,4 +46,9 @@ public class FRDomesticStandingOrderPaymentSubmission implements PaymentSubmissi
     private String idempotencyKey;
 
     private OBVersion obVersion;
+
+    @Override
+    public String getConsentId() {
+        return standingOrder.getData().getConsentId();
+    }
 }

--- a/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/persistence/document/payment/FRFilePaymentSubmission.java
+++ b/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/persistence/document/payment/FRFilePaymentSubmission.java
@@ -47,4 +47,9 @@ public class FRFilePaymentSubmission implements PaymentSubmission {
     private String idempotencyKey;
 
     private OBVersion obVersion;
+
+    @Override
+    public String getConsentId() {
+        return filePayment.getData().getConsentId();
+    }
 }

--- a/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/persistence/document/payment/FRInternationalPaymentSubmission.java
+++ b/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/persistence/document/payment/FRInternationalPaymentSubmission.java
@@ -37,7 +37,7 @@ public class FRInternationalPaymentSubmission implements PaymentSubmission {
     @Indexed
     private String id;
 
-    private FRWriteInternational internationalPayment;
+    private FRWriteInternational payment;
 
     private FRSubmissionStatus status;
 
@@ -54,7 +54,12 @@ public class FRInternationalPaymentSubmission implements PaymentSubmission {
      * @return {@link FRExchangeRateInformation} with rate and expiry date fields populated where appropriate.
      */
     public FRExchangeRateInformation getCalculatedExchangeRate() {
-        FRExchangeRateInformation exchangeRateInformation = internationalPayment.getData().getInitiation().getExchangeRateInformation();
+        FRExchangeRateInformation exchangeRateInformation = payment.getData().getInitiation().getExchangeRateInformation();
         return CurrencyRateService.getCalculatedExchangeRate(exchangeRateInformation, created);
+    }
+
+    @Override
+    public String getConsentId() {
+        return payment.getData().getConsentId();
     }
 }

--- a/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/persistence/document/payment/FRInternationalScheduledPaymentSubmission.java
+++ b/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/persistence/document/payment/FRInternationalScheduledPaymentSubmission.java
@@ -36,7 +36,7 @@ public class FRInternationalScheduledPaymentSubmission implements PaymentSubmiss
     @Indexed
     private String id;
 
-    private FRWriteInternationalScheduled internationalScheduledPayment;
+    private FRWriteInternationalScheduled scheduledPayment;
 
     private FRSubmissionStatus status;
 
@@ -50,7 +50,12 @@ public class FRInternationalScheduledPaymentSubmission implements PaymentSubmiss
     private OBVersion obVersion;
 
     public FRExchangeRateInformation getCalculatedExchangeRate() {
-        FRExchangeRateInformation exchangeRateInformation = internationalScheduledPayment.getData().getInitiation().getExchangeRateInformation();
+        FRExchangeRateInformation exchangeRateInformation = scheduledPayment.getData().getInitiation().getExchangeRateInformation();
         return CurrencyRateService.getCalculatedExchangeRate(exchangeRateInformation, created);
+    }
+
+    @Override
+    public String getConsentId() {
+        return scheduledPayment.getData().getConsentId();
     }
 }

--- a/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/persistence/document/payment/FRInternationalStandingOrderPaymentSubmission.java
+++ b/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/persistence/document/payment/FRInternationalStandingOrderPaymentSubmission.java
@@ -34,7 +34,7 @@ public class FRInternationalStandingOrderPaymentSubmission implements PaymentSub
     @Indexed
     private String id;
 
-    private FRWriteInternationalStandingOrder internationalStandingOrder;
+    private FRWriteInternationalStandingOrder standingOrder;
 
     private FRSubmissionStatus status;
 
@@ -46,4 +46,9 @@ public class FRInternationalStandingOrderPaymentSubmission implements PaymentSub
     private String idempotencyKey;
 
     private OBVersion version;
+
+    @Override
+    public String getConsentId() {
+        return standingOrder.getData().getConsentId();
+    }
 }

--- a/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/persistence/document/payment/PaymentSubmission.java
+++ b/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/persistence/document/payment/PaymentSubmission.java
@@ -20,6 +20,8 @@ import org.joda.time.DateTime;
 public interface PaymentSubmission {
     String getId();
 
+    String getConsentId();
+
     DateTime getCreated();
 
     String getIdempotencyKey();

--- a/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/persistence/repository/payments/DomesticScheduledPaymentSubmissionRepository.java
+++ b/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/persistence/repository/payments/DomesticScheduledPaymentSubmissionRepository.java
@@ -16,7 +16,6 @@
 package com.forgerock.securebanking.openbanking.uk.rs.persistence.repository.payments;
 
 import com.forgerock.securebanking.openbanking.uk.rs.persistence.document.payment.FRDomesticScheduledPaymentSubmission;
-import org.springframework.data.mongodb.repository.MongoRepository;
 
-public interface DomesticScheduledPaymentSubmissionRepository extends MongoRepository<FRDomesticScheduledPaymentSubmission, String> {
+public interface DomesticScheduledPaymentSubmissionRepository extends PaymentSubmissionRepository<FRDomesticScheduledPaymentSubmission> {
 }

--- a/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/persistence/repository/payments/DomesticStandingOrderPaymentSubmissionRepository.java
+++ b/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/persistence/repository/payments/DomesticStandingOrderPaymentSubmissionRepository.java
@@ -16,7 +16,6 @@
 package com.forgerock.securebanking.openbanking.uk.rs.persistence.repository.payments;
 
 import com.forgerock.securebanking.openbanking.uk.rs.persistence.document.payment.FRDomesticStandingOrderPaymentSubmission;
-import org.springframework.data.mongodb.repository.MongoRepository;
 
-public interface DomesticStandingOrderPaymentSubmissionRepository extends MongoRepository<FRDomesticStandingOrderPaymentSubmission, String> {
+public interface DomesticStandingOrderPaymentSubmissionRepository extends PaymentSubmissionRepository<FRDomesticStandingOrderPaymentSubmission> {
 }

--- a/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/persistence/repository/payments/FilePaymentSubmissionRepository.java
+++ b/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/persistence/repository/payments/FilePaymentSubmissionRepository.java
@@ -16,7 +16,6 @@
 package com.forgerock.securebanking.openbanking.uk.rs.persistence.repository.payments;
 
 import com.forgerock.securebanking.openbanking.uk.rs.persistence.document.payment.FRFilePaymentSubmission;
-import org.springframework.data.mongodb.repository.MongoRepository;
 
-public interface FilePaymentSubmissionRepository extends MongoRepository<FRFilePaymentSubmission, String> {
+public interface FilePaymentSubmissionRepository extends PaymentSubmissionRepository<FRFilePaymentSubmission> {
 }

--- a/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/persistence/repository/payments/InternationalPaymentSubmissionRepository.java
+++ b/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/persistence/repository/payments/InternationalPaymentSubmissionRepository.java
@@ -16,7 +16,6 @@
 package com.forgerock.securebanking.openbanking.uk.rs.persistence.repository.payments;
 
 import com.forgerock.securebanking.openbanking.uk.rs.persistence.document.payment.FRInternationalPaymentSubmission;
-import org.springframework.data.mongodb.repository.MongoRepository;
 
-public interface InternationalPaymentSubmissionRepository extends MongoRepository<FRInternationalPaymentSubmission, String> {
+public interface InternationalPaymentSubmissionRepository extends PaymentSubmissionRepository<FRInternationalPaymentSubmission> {
 }

--- a/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/persistence/repository/payments/InternationalScheduledPaymentSubmissionRepository.java
+++ b/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/persistence/repository/payments/InternationalScheduledPaymentSubmissionRepository.java
@@ -16,7 +16,6 @@
 package com.forgerock.securebanking.openbanking.uk.rs.persistence.repository.payments;
 
 import com.forgerock.securebanking.openbanking.uk.rs.persistence.document.payment.FRInternationalScheduledPaymentSubmission;
-import org.springframework.data.mongodb.repository.MongoRepository;
 
-public interface InternationalScheduledPaymentSubmissionRepository extends MongoRepository<FRInternationalScheduledPaymentSubmission, String> {
+public interface InternationalScheduledPaymentSubmissionRepository extends PaymentSubmissionRepository<FRInternationalScheduledPaymentSubmission> {
 }

--- a/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/persistence/repository/payments/InternationalStandingOrderPaymentSubmissionRepository.java
+++ b/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/persistence/repository/payments/InternationalStandingOrderPaymentSubmissionRepository.java
@@ -16,7 +16,6 @@
 package com.forgerock.securebanking.openbanking.uk.rs.persistence.repository.payments;
 
 import com.forgerock.securebanking.openbanking.uk.rs.persistence.document.payment.FRInternationalStandingOrderPaymentSubmission;
-import org.springframework.data.mongodb.repository.MongoRepository;
 
-public interface InternationalStandingOrderPaymentSubmissionRepository extends MongoRepository<FRInternationalStandingOrderPaymentSubmission, String> {
+public interface InternationalStandingOrderPaymentSubmissionRepository extends PaymentSubmissionRepository<FRInternationalStandingOrderPaymentSubmission> {
 }

--- a/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/persistence/repository/payments/PaymentSubmissionRepository.java
+++ b/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/persistence/repository/payments/PaymentSubmissionRepository.java
@@ -15,7 +15,15 @@
  */
 package com.forgerock.securebanking.openbanking.uk.rs.persistence.repository.payments;
 
-import com.forgerock.securebanking.openbanking.uk.rs.persistence.document.payment.FRDomesticPaymentSubmission;
+import com.forgerock.securebanking.openbanking.uk.rs.persistence.document.payment.PaymentSubmission;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-public interface DomesticPaymentSubmissionRepository extends PaymentSubmissionRepository<FRDomesticPaymentSubmission> {
+import java.util.Optional;
+
+public interface PaymentSubmissionRepository<T extends PaymentSubmission> extends MongoRepository<T, String> {
+
+    @Query("{'payment.data.consentId' : ?0}")
+    Optional<T> findByConsentId(@Param("consentId") String consentId);
 }

--- a/securebanking-openbanking-uk-rs-simulator/src/main/resources/application.yml
+++ b/securebanking-openbanking-uk-rs-simulator/src/main/resources/application.yml
@@ -11,6 +11,12 @@ rs:
         accounts: 100
         documents: 1000
 
+#Spring
+spring:
+  data:
+    mongodb:
+      database: mongo
+
 #Swagger
 springfox:
   documentation:


### PR DESCRIPTION
### Check for existing payment submissions for the same Consent ID

Rather than saving a payment submission with its primary key set to the consent's ID, this change ensures each submission has its own unique ID. This means that the `IdempotentRepositoryAdapter` needs to find any existing payment submissions for the consent in question by the consent's ID, rather than the submission's ID.

There are quite a few minor changes to several classes in this PR, but the pertinent changes were made to these classes:

- `PaymentSubmissionRepository` (new repository interface with the required `findByConsentId` method).
- `PaymentSubmission` (each Submission knows how to return its consentId).
- `IdempotentRepositoryAdapter` (using `findByConsentId`).
- `DomesticPaymentsApiControllerTest` (new test methods concerning the above).

Issue: https://github.com/SecureBankingAcceleratorToolkit/SecureBankingAcceleratorToolkit/issues/45