### PR TITLE
51 - Callback URLs API controllers

### DIFF
--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/event/v3_0/CallbackUrlsApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/event/v3_0/CallbackUrlsApi.java
@@ -65,7 +65,7 @@ public interface CallbackUrlsApi {
     ResponseEntity<OBCallbackUrlResponse1> createCallbackUrls(
             @ApiParam(value = "Default", required = true)
             @Valid
-            @RequestBody OBCallbackUrl1 obCallbackUrl1Param,
+            @RequestBody OBCallbackUrl1 obCallbackUrl1,
 
             @ApiParam(value = "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.", required = true)
             @RequestHeader(value = "x-fapi-financial-id", required = true) String xFapiFinancialId,
@@ -73,8 +73,8 @@ public interface CallbackUrlsApi {
             @ApiParam(value = "An Authorisation Token as per https://tools.ietf.org/html/rfc6750", required = true)
             @RequestHeader(value = "Authorization", required = true) String authorization,
 
-            @ApiParam(value = "Header containing a detached JWS signature of the body of the payload." ,required=true)
-            @RequestHeader(value="x-jws-signature", required=false) String xJwsSignature,
+            @ApiParam(value = "Header containing a detached JWS signature of the body of the payload.", required = true)
+            @RequestHeader(value = "x-jws-signature", required = false) String xJwsSignature,
 
             @ApiParam(value = "An RFC4122 UID used as a correlation id.")
             @RequestHeader(value = "x-fapi-interaction-id", required = false) String xFapiInteractionId,
@@ -143,7 +143,7 @@ public interface CallbackUrlsApi {
             @ApiResponse(code = 429, message = "Too Many Requests"),
             @ApiResponse(code = 500, message = "Internal Server Error", response = OBErrorResponse1.class)})
 
-    @RequestMapping(value = BASE_PATH+"/{CallbackUrlId}",
+    @RequestMapping(value = BASE_PATH + "/{CallbackUrlId}",
             produces = {"application/json; charset=utf-8"},
             consumes = {"application/json; charset=utf-8"},
             method = RequestMethod.PUT)
@@ -153,7 +153,7 @@ public interface CallbackUrlsApi {
 
             @ApiParam(value = "Default", required = true)
             @Valid
-            @RequestBody OBCallbackUrl1 obCallbackUrl1Param,
+            @RequestBody OBCallbackUrl1 obCallbackUrl1,
 
             @ApiParam(value = "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.", required = false)
             @RequestHeader(value = "x-fapi-financial-id", required = true) String xFapiFinancialId,
@@ -193,7 +193,7 @@ public interface CallbackUrlsApi {
             @ApiResponse(code = 429, message = "Too Many Requests"),
             @ApiResponse(code = 500, message = "Internal Server Error", response = OBErrorResponse1.class)})
 
-    @RequestMapping(value = BASE_PATH+"/{CallbackUrlId}",
+    @RequestMapping(value = BASE_PATH + "/{CallbackUrlId}",
             method = RequestMethod.DELETE)
     ResponseEntity deleteCallbackUrl(
             @ApiParam(value = "CallbackUrlId", required = true)

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/event/v3_1_2/callbackurl/CallbackUrlsApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/event/v3_1_2/callbackurl/CallbackUrlsApi.java
@@ -65,13 +65,13 @@ public interface CallbackUrlsApi {
     ResponseEntity<OBCallbackUrlResponse1> createCallbackUrls(
             @ApiParam(value = "Default", required = true)
             @Valid
-            @RequestBody OBCallbackUrl1 obCallbackUrl1Param,
+            @RequestBody OBCallbackUrl1 obCallbackUrl1,
 
             @ApiParam(value = "An Authorisation Token as per https://tools.ietf.org/html/rfc6750", required = true)
             @RequestHeader(value = "Authorization", required = true) String authorization,
 
-            @ApiParam(value = "Header containing a detached JWS signature of the body of the payload." ,required=true)
-            @RequestHeader(value="x-jws-signature", required=false) String xJwsSignature,
+            @ApiParam(value = "Header containing a detached JWS signature of the body of the payload.", required = true)
+            @RequestHeader(value = "x-jws-signature", required = false) String xJwsSignature,
 
             @ApiParam(value = "An RFC4122 UID used as a correlation id.")
             @RequestHeader(value = "x-fapi-interaction-id", required = false) String xFapiInteractionId,
@@ -137,7 +137,7 @@ public interface CallbackUrlsApi {
             @ApiResponse(code = 429, message = "Too Many Requests"),
             @ApiResponse(code = 500, message = "Internal Server Error", response = OBErrorResponse1.class)})
 
-    @RequestMapping(value = BASE_PATH+"/{CallbackUrlId}",
+    @RequestMapping(value = BASE_PATH + "/{CallbackUrlId}",
             produces = {"application/json; charset=utf-8"},
             consumes = {"application/json; charset=utf-8"},
             method = RequestMethod.PUT)
@@ -147,7 +147,7 @@ public interface CallbackUrlsApi {
 
             @ApiParam(value = "Default", required = true)
             @Valid
-            @RequestBody OBCallbackUrl1 obCallbackUrl1Param,
+            @RequestBody OBCallbackUrl1 obCallbackUrl1,
 
             @ApiParam(value = "An Authorisation Token as per https://tools.ietf.org/html/rfc6750", required = true)
             @RequestHeader(value = "Authorization", required = true) String authorization,
@@ -184,7 +184,7 @@ public interface CallbackUrlsApi {
             @ApiResponse(code = 429, message = "Too Many Requests"),
             @ApiResponse(code = 500, message = "Internal Server Error", response = OBErrorResponse1.class)})
 
-    @RequestMapping(value = BASE_PATH+"/{CallbackUrlId}",
+    @RequestMapping(value = BASE_PATH + "/{CallbackUrlId}",
             method = RequestMethod.DELETE)
     ResponseEntity deleteCallbackUrl(
             @ApiParam(value = "CallbackUrlId", required = true)
@@ -203,5 +203,4 @@ public interface CallbackUrlsApi {
 
             Principal principal
     ) throws OBErrorResponseException;
-
 }

--- a/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/event/v3_0/CallbackUrlsApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/event/v3_0/CallbackUrlsApiController.java
@@ -1,0 +1,180 @@
+/**
+ * Copyright © 2020 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.securebanking.openbanking.uk.rs.api.obie.event.v3_0;
+
+
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.OBVersion;
+import com.forgerock.securebanking.openbanking.uk.error.OBErrorResponseException;
+import com.forgerock.securebanking.openbanking.uk.error.OBRIErrorResponseCategory;
+import com.forgerock.securebanking.openbanking.uk.error.OBRIErrorType;
+import com.forgerock.securebanking.openbanking.uk.rs.persistence.document.event.FRCallbackUrl;
+import com.forgerock.securebanking.openbanking.uk.rs.persistence.repository.events.CallbackUrlsRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import uk.org.openbanking.datamodel.event.OBCallbackUrl1;
+import uk.org.openbanking.datamodel.event.OBCallbackUrlsResponse1;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.validation.Valid;
+import java.security.Principal;
+import java.util.*;
+
+import static com.forgerock.securebanking.openbanking.uk.rs.common.util.EventApiResponseUtil.isAccessToResourceAllowed;
+import static com.forgerock.securebanking.openbanking.uk.rs.common.util.EventApiResponseUtil.packageResponse;
+import static com.forgerock.securebanking.openbanking.uk.rs.common.util.VersionPathExtractor.getVersionFromPath;
+import static com.forgerock.securebanking.openbanking.uk.rs.converter.event.FRCallbackUrlConverter.toFRCallbackUrlData;
+import static org.springframework.http.HttpStatus.*;
+
+@Controller("CallbackUrlsApiV3.0")
+@Slf4j
+public class CallbackUrlsApiController implements CallbackUrlsApi {
+
+    private final CallbackUrlsRepository callbackUrlsRepository;
+
+    public CallbackUrlsApiController(CallbackUrlsRepository callbackUrlsRepository) {
+        this.callbackUrlsRepository = callbackUrlsRepository;
+    }
+
+    @Override
+    public ResponseEntity createCallbackUrls(
+            @Valid OBCallbackUrl1 obCallbackUrl1,
+            String xFapiFinancialId,
+            String authorization,
+            String xJwsSignature,
+            String xFapiInteractionId,
+            String tppId,
+            HttpServletRequest request,
+            Principal principal
+    ) throws OBErrorResponseException {
+        log.debug("Create new callback URL: {} for TPP: {}", obCallbackUrl1, tppId);
+        String newUrl = obCallbackUrl1.getData().getUrl();
+
+        // Check if callback URL already exists for TPP
+        Collection<FRCallbackUrl> callbackUrls = callbackUrlsRepository.findByTppId(tppId);
+        boolean callbackExists = callbackUrls.stream()
+                .anyMatch(existingUrl -> newUrl.equals(existingUrl.getCallbackUrl().getUrl()));
+        if (callbackExists) {
+            log.debug("This callback URL: '{}' already exists for this TPP id: '{}'", newUrl, tppId);
+            throw new OBErrorResponseException(
+                    CONFLICT,
+                    OBRIErrorResponseCategory.REQUEST_INVALID,
+                    OBRIErrorType.CALLBACK_URL_ALREADY_EXISTS.toOBError1(newUrl)
+            );
+        }
+
+        FRCallbackUrl frCallbackUrl = FRCallbackUrl.builder()
+                .id(UUID.randomUUID().toString())
+                .tppId(tppId)
+                .callbackUrl(toFRCallbackUrlData(obCallbackUrl1))
+                .build();
+        callbackUrlsRepository.save(frCallbackUrl);
+
+        return ResponseEntity
+                .status(CREATED)
+                .body(packageResponse(frCallbackUrl, getVersionFromPath(request)));
+    }
+
+    @Override
+    public ResponseEntity<OBCallbackUrlsResponse1> readCallBackUrls(
+            String xFapiFinancialId,
+            String authorization,
+            String xFapiInteractionId,
+            String tppId,
+            HttpServletRequest request,
+            Principal principal
+    ) {
+        Collection<FRCallbackUrl> callbackUrls = callbackUrlsRepository.findByTppId(tppId);
+        if (callbackUrls.isEmpty()) {
+            log.warn("No CallbackURL found for tpp id '{}'", tppId);
+            return ResponseEntity.ok(packageResponse(Collections.emptyList(), getVersionFromPath(request)));
+        }
+        // A TPP must only create a callback-url on one version
+        return ResponseEntity.ok(packageResponse(new ArrayList<>(callbackUrls), getVersionFromPath(request)));
+    }
+
+    @Override
+    public ResponseEntity updateCallbackUrl(
+            String callbackUrlId,
+            @Valid OBCallbackUrl1 obCallbackUrl1,
+            String xFapiFinancialId,
+            String authorization,
+            String xJwsSignature,
+            String xFapiInteractionId,
+            String tppId,
+            HttpServletRequest request,
+            Principal principal
+    ) throws OBErrorResponseException {
+        Optional<FRCallbackUrl> byId = callbackUrlsRepository.findById(callbackUrlId);
+
+        if (byId.isPresent()) {
+            FRCallbackUrl frCallbackUrl = byId.get();
+            OBVersion apiVersion = getVersionFromPath(request);
+            OBVersion resourceVersion = OBVersion.fromString(frCallbackUrl.getCallbackUrl().getVersion());
+            if (isAccessToResourceAllowed(apiVersion, resourceVersion)) {
+                frCallbackUrl.setCallbackUrl(toFRCallbackUrlData(obCallbackUrl1));
+                callbackUrlsRepository.save(frCallbackUrl);
+                return ResponseEntity.ok(packageResponse(frCallbackUrl, apiVersion));
+            } else {
+                return ResponseEntity
+                        .status(CONFLICT)
+                        .body("Callback URL: '" + callbackUrlId + "' can't be updated via an older API version.");
+            }
+        } else {
+            // Spec isn't clear on if we should
+            // 1. Reject a PUT for a resource id that does not exist
+            // 2. Create a new resource for a PUT for resource id that does not exist
+            // Option 2 is more restful but the examples in spec only use PUT for amending urls so currently I am implementing option 1.
+            throw new OBErrorResponseException(
+                    BAD_REQUEST,
+                    OBRIErrorResponseCategory.REQUEST_INVALID,
+                    OBRIErrorType.CALLBACK_URL_NOT_FOUND.toOBError1(callbackUrlId)
+            );
+        }
+    }
+
+    @Override
+    public ResponseEntity deleteCallbackUrl(
+            String callbackUrlId,
+            String xFapiFinancialId,
+            String authorization,
+            String xFapiInteractionId,
+            String tppId,
+            HttpServletRequest request,
+            Principal principal
+    ) throws OBErrorResponseException {
+        Optional<FRCallbackUrl> byId = callbackUrlsRepository.findById(callbackUrlId);
+        if (byId.isPresent()) {
+            OBVersion apiVersion = getVersionFromPath(request);
+            OBVersion resourceVersion = OBVersion.fromString(byId.get().getCallbackUrl().getVersion());
+            if (isAccessToResourceAllowed(apiVersion, resourceVersion)) {
+                log.debug("Deleting callback url: {}", byId.get());
+                callbackUrlsRepository.deleteById(callbackUrlId);
+                return ResponseEntity.noContent().build();
+            } else {
+                return ResponseEntity
+                        .status(CONFLICT)
+                        .body("Callback URL: '" + callbackUrlId + "' can't be deleted via an older API version.");
+            }
+        } else {
+            throw new OBErrorResponseException(
+                    BAD_REQUEST,
+                    OBRIErrorResponseCategory.REQUEST_INVALID,
+                    OBRIErrorType.CALLBACK_URL_NOT_FOUND.toOBError1(callbackUrlId)
+            );
+        }
+    }
+}

--- a/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/event/v3_1/CallbackUrlsApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/event/v3_1/CallbackUrlsApiController.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright © 2020 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.securebanking.openbanking.uk.rs.api.obie.event.v3_1;
+
+import com.forgerock.securebanking.openbanking.uk.rs.persistence.repository.events.CallbackUrlsRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Controller;
+
+@Controller("CallbackUrlsApiV3.1")
+@Slf4j
+public class CallbackUrlsApiController extends com.forgerock.securebanking.openbanking.uk.rs.api.obie.event.v3_0.CallbackUrlsApiController implements CallbackUrlsApi {
+
+    public CallbackUrlsApiController(CallbackUrlsRepository callbackUrlsRepository) {
+        super(callbackUrlsRepository);
+    }
+}

--- a/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/event/v3_1_1/CallbackUrlsApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/event/v3_1_1/CallbackUrlsApiController.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright © 2020 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.securebanking.openbanking.uk.rs.api.obie.event.v3_1_1;
+
+
+import com.forgerock.securebanking.openbanking.uk.rs.persistence.repository.events.CallbackUrlsRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Controller;
+
+@Controller("CallbackUrlsApiV3.1.1")
+@Slf4j
+public class CallbackUrlsApiController extends com.forgerock.securebanking.openbanking.uk.rs.api.obie.event.v3_1.CallbackUrlsApiController implements CallbackUrlsApi {
+
+    public CallbackUrlsApiController(CallbackUrlsRepository callbackUrlsRepository) {
+        super(callbackUrlsRepository);
+    }
+}

--- a/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/event/v3_1_2/callbackurl/CallbackUrlsApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/event/v3_1_2/callbackurl/CallbackUrlsApiController.java
@@ -1,0 +1,179 @@
+/**
+ * Copyright © 2020 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.securebanking.openbanking.uk.rs.api.obie.event.v3_1_2.callbackurl;
+
+import com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.event.FRCallbackUrlData;
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.OBVersion;
+import com.forgerock.securebanking.openbanking.uk.error.OBErrorResponseException;
+import com.forgerock.securebanking.openbanking.uk.error.OBRIErrorResponseCategory;
+import com.forgerock.securebanking.openbanking.uk.error.OBRIErrorType;
+import com.forgerock.securebanking.openbanking.uk.rs.common.util.EventApiResponseUtil;
+import com.forgerock.securebanking.openbanking.uk.rs.persistence.document.event.FRCallbackUrl;
+import com.forgerock.securebanking.openbanking.uk.rs.persistence.repository.events.CallbackUrlsRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import uk.org.openbanking.datamodel.event.OBCallbackUrl1;
+import uk.org.openbanking.datamodel.event.OBCallbackUrlResponse1;
+import uk.org.openbanking.datamodel.event.OBCallbackUrlsResponse1;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.validation.Valid;
+import java.security.Principal;
+import java.util.*;
+
+import static com.forgerock.securebanking.openbanking.uk.rs.common.util.EventApiResponseUtil.packageResponse;
+import static com.forgerock.securebanking.openbanking.uk.rs.common.util.VersionPathExtractor.getVersionFromPath;
+import static com.forgerock.securebanking.openbanking.uk.rs.converter.event.FRCallbackUrlConverter.toFRCallbackUrlData;
+import static org.springframework.http.HttpStatus.*;
+
+@Controller("CallbackUrlsApiV3.1.2")
+@Slf4j
+public class CallbackUrlsApiController implements CallbackUrlsApi {
+
+    private final CallbackUrlsRepository callbackUrlsRepository;
+
+    public CallbackUrlsApiController(CallbackUrlsRepository callbackUrlsRepository) {
+        this.callbackUrlsRepository = callbackUrlsRepository;
+    }
+
+    @Override
+    public ResponseEntity<OBCallbackUrlResponse1> createCallbackUrls(
+            @Valid OBCallbackUrl1 obCallbackUrl1,
+            String authorization,
+            String xJwsSignature,
+            String xFapiInteractionId,
+            String tppId,
+            HttpServletRequest request,
+            Principal principal
+    ) throws OBErrorResponseException {
+        log.debug("Create new callback URL: {} for TPP: {}", obCallbackUrl1, tppId);
+        String newUrl = obCallbackUrl1.getData().getUrl();
+
+        // Check if callback URL already exists for TPP
+        Collection<FRCallbackUrl> callbackUrls = callbackUrlsRepository.findByTppId(tppId);
+        boolean callbackExists = callbackUrls.stream()
+                .anyMatch(existingUrl -> newUrl.equals(existingUrl.getCallbackUrl().getUrl()));
+        if (callbackExists) {
+            log.debug("This callback URL: '{}' already exists for this TPP id: '{}'", newUrl, tppId);
+            throw new OBErrorResponseException(
+                    CONFLICT,
+                    OBRIErrorResponseCategory.REQUEST_INVALID,
+                    OBRIErrorType.CALLBACK_URL_ALREADY_EXISTS.toOBError1(newUrl)
+            );
+        }
+
+        FRCallbackUrl frCallbackUrl = FRCallbackUrl.builder()
+                .id(UUID.randomUUID().toString())
+                .tppId(tppId)
+                .callbackUrl(toFRCallbackUrlData(obCallbackUrl1))
+                .build();
+        callbackUrlsRepository.save(frCallbackUrl);
+
+        return ResponseEntity
+                .status(CREATED)
+                .body(packageResponse(frCallbackUrl, getVersionFromPath(request)));
+    }
+
+    @Override
+    public ResponseEntity readCallBackUrls(
+            String authorization,
+            String xFapiInteractionId,
+            String tppId,
+            HttpServletRequest request,
+            Principal principal
+    ) {
+        Collection<FRCallbackUrl> callbackUrls = callbackUrlsRepository.findByTppId(tppId);
+        if (callbackUrls.isEmpty()) {
+            log.warn("No CallbackURL found for tpp id '{}'", tppId);
+            return ResponseEntity.ok(packageResponse(Collections.emptyList(), getVersionFromPath(request)));
+        }
+        // A TPP must only create a callback-url on one version
+        OBCallbackUrlsResponse1 responseBody = packageResponse(new ArrayList<>(callbackUrls), getVersionFromPath(request));
+        return ResponseEntity.ok(responseBody);
+    }
+
+    @Override
+    public ResponseEntity updateCallbackUrl(
+            String callbackUrlId,
+            @Valid OBCallbackUrl1 obCallbackUrl1,
+            String authorization,
+            String xJwsSignature,
+            String xFapiInteractionId,
+            String tppId,
+            HttpServletRequest request,
+            Principal principal
+    ) throws OBErrorResponseException {
+        Optional<FRCallbackUrl> byId = callbackUrlsRepository.findById(callbackUrlId);
+
+        if (byId.isPresent()) {
+            FRCallbackUrl frCallbackUrl = byId.get();
+            OBVersion apiVersion = getVersionFromPath(request);
+            OBVersion resourceVersion = OBVersion.fromString(frCallbackUrl.getCallbackUrl().getVersion());
+            if (EventApiResponseUtil.isAccessToResourceAllowed(apiVersion, resourceVersion)) {
+                FRCallbackUrlData callbackUrl = toFRCallbackUrlData(obCallbackUrl1);
+                frCallbackUrl.setCallbackUrl(callbackUrl);
+                callbackUrlsRepository.save(frCallbackUrl);
+                return ResponseEntity.ok(packageResponse(frCallbackUrl, apiVersion));
+            } else {
+                return ResponseEntity
+                        .status(CONFLICT)
+                        .body("Callback URL: '" + callbackUrlId + "' can't be updated via an older API version.");
+            }
+        } else {
+            // Spec isn't clear on if we should
+            // 1. Reject a PUT for a resource id that does not exist
+            // 2. Create a new resource for a PUT for resource id that does not exist
+            // Option 2 is more restful but the examples in spec only use PUT for amending urls so currently I am implementing option 1.
+            throw new OBErrorResponseException(
+                    BAD_REQUEST,
+                    OBRIErrorResponseCategory.REQUEST_INVALID,
+                    OBRIErrorType.CALLBACK_URL_NOT_FOUND.toOBError1(callbackUrlId)
+            );
+        }
+    }
+
+    @Override
+    public ResponseEntity deleteCallbackUrl(
+            String callbackUrlId,
+            String authorization,
+            String xFapiInteractionId,
+            String tppId,
+            HttpServletRequest request,
+            Principal principal
+    ) throws OBErrorResponseException {
+        Optional<FRCallbackUrl> byId = callbackUrlsRepository.findById(callbackUrlId);
+        if (byId.isPresent()) {
+            OBVersion apiVersion = getVersionFromPath(request);
+            OBVersion resourceVersion = OBVersion.fromString(byId.get().getCallbackUrl().getVersion());
+            if (EventApiResponseUtil.isAccessToResourceAllowed(apiVersion, resourceVersion)) {
+                log.debug("Deleting callback url: {}", byId.get());
+                callbackUrlsRepository.deleteById(callbackUrlId);
+                return ResponseEntity.noContent().build();
+            } else {
+                return ResponseEntity
+                        .status(CONFLICT)
+                        .body("Callback URL: '" + callbackUrlId + "' can't be deleted via an older API version.");
+            }
+        } else {
+            throw new OBErrorResponseException(
+                    BAD_REQUEST,
+                    OBRIErrorResponseCategory.REQUEST_INVALID,
+                    OBRIErrorType.CALLBACK_URL_NOT_FOUND.toOBError1(callbackUrlId)
+            );
+        }
+    }
+}

--- a/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/event/v3_1_3/callbackurl/CallbackUrlsApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/event/v3_1_3/callbackurl/CallbackUrlsApiController.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright © 2020 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.securebanking.openbanking.uk.rs.api.obie.event.v3_1_3.callbackurl;
+
+import com.forgerock.securebanking.openbanking.uk.rs.persistence.repository.events.CallbackUrlsRepository;
+import org.springframework.stereotype.Controller;
+
+@Controller("CallbackUrlsApiV3.1.3")
+public class CallbackUrlsApiController extends com.forgerock.securebanking.openbanking.uk.rs.api.obie.event.v3_1_2.callbackurl.CallbackUrlsApiController implements CallbackUrlsApi {
+
+    public CallbackUrlsApiController(CallbackUrlsRepository callbackUrlsRepository) {
+        super(callbackUrlsRepository);
+    }
+}

--- a/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/event/v3_1_4/callbackurl/CallbackUrlsApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/event/v3_1_4/callbackurl/CallbackUrlsApiController.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright © 2020 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.securebanking.openbanking.uk.rs.api.obie.event.v3_1_4.callbackurl;
+
+import com.forgerock.securebanking.openbanking.uk.rs.persistence.repository.events.CallbackUrlsRepository;
+import org.springframework.stereotype.Controller;
+
+@Controller("CallbackUrlsApiV3.1.4")
+public class CallbackUrlsApiController extends com.forgerock.securebanking.openbanking.uk.rs.api.obie.event.v3_1_3.callbackurl.CallbackUrlsApiController implements CallbackUrlsApi {
+
+    public CallbackUrlsApiController(CallbackUrlsRepository callbackUrlsRepository) {
+        super(callbackUrlsRepository);
+    }
+}

--- a/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/event/v3_1_5/callbackurl/CallbackUrlsApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/event/v3_1_5/callbackurl/CallbackUrlsApiController.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright © 2020 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.securebanking.openbanking.uk.rs.api.obie.event.v3_1_5.callbackurl;
+
+import com.forgerock.securebanking.openbanking.uk.rs.persistence.repository.events.CallbackUrlsRepository;
+import org.springframework.stereotype.Controller;
+
+@Controller("CallbackUrlsApiV3.1.5")
+public class CallbackUrlsApiController extends com.forgerock.securebanking.openbanking.uk.rs.api.obie.event.v3_1_4.callbackurl.CallbackUrlsApiController implements CallbackUrlsApi {
+
+    public CallbackUrlsApiController(CallbackUrlsRepository callbackUrlsRepository) {
+        super(callbackUrlsRepository);
+    }
+}

--- a/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/event/v3_1_6/callbackurl/CallbackUrlsApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/event/v3_1_6/callbackurl/CallbackUrlsApiController.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright © 2020 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.securebanking.openbanking.uk.rs.api.obie.event.v3_1_6.callbackurl;
+
+import com.forgerock.securebanking.openbanking.uk.rs.persistence.repository.events.CallbackUrlsRepository;
+import org.springframework.stereotype.Controller;
+
+@Controller("CallbackUrlsApiV3.1.6")
+public class CallbackUrlsApiController extends com.forgerock.securebanking.openbanking.uk.rs.api.obie.event.v3_1_5.callbackurl.CallbackUrlsApiController implements CallbackUrlsApi {
+
+    public CallbackUrlsApiController(CallbackUrlsRepository callbackUrlsRepository) {
+        super(callbackUrlsRepository);
+    }
+}

--- a/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/common/util/EventApiResponseUtil.java
+++ b/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/common/util/EventApiResponseUtil.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright © 2020 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.securebanking.openbanking.uk.rs.common.util;
+
+import com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.event.FRCallbackUrlData;
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.OBVersion;
+import com.forgerock.securebanking.openbanking.uk.rs.persistence.document.event.FRCallbackUrl;
+import lombok.extern.slf4j.Slf4j;
+import uk.org.openbanking.datamodel.account.Links;
+import uk.org.openbanking.datamodel.account.Meta;
+import uk.org.openbanking.datamodel.event.OBCallbackUrlResponse1;
+import uk.org.openbanking.datamodel.event.OBCallbackUrlResponseData1;
+import uk.org.openbanking.datamodel.event.OBCallbackUrlsResponse1;
+import uk.org.openbanking.datamodel.event.OBCallbackUrlsResponseData1;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.forgerock.securebanking.openbanking.uk.common.api.meta.OBVersion.v3_0;
+
+/**
+ * Helps build responses for the Event Notification API, according to the "Release Management" rules of the OB API. For
+ * example, refer to https://openbankinguk.github.io/read-write-api-site3/v3.1.3/profiles/callback-url-api-profile.html#release-management
+ */
+@Slf4j
+public class EventApiResponseUtil {
+
+    /**
+     * Checks if a resource can be accessed from the version of the API that's currently being invoked. The OB spec
+     * states that a TPP cannot access a resource from an older API version if the resource was created in a newer
+     * version.
+     *
+     * <p>
+     * This method is being used to filter any resources that cannot be accessed via the version of the API version
+     * in question.
+     *
+     * @param apiVersion The version of the API currently being invoked.
+     * @param resourceVersion The version of the API that the resource was saved against.
+     * @return {@code true} if the resource is allowed to be accessed, otherwise false.
+     */
+    public static boolean isAccessToResourceAllowed(OBVersion apiVersion, OBVersion resourceVersion) {
+        return apiVersion.equals(resourceVersion) ||
+                apiVersion.isAfterVersion(resourceVersion);
+    }
+
+    /**
+     * Provides the required {@link OBCallbackUrlsResponse1} instance, filtered according to the API version rules. Any
+     * resources that cannot be accessed via the API version in use are filtered from the response.
+     *
+     * @param apiVersion The version of the API currently being invoked.
+     * @param frCallbackUrls A {@link List} {@link FRCallbackUrl} to be returned in the response.
+     * @return The {@link OBCallbackUrlsResponse1}, containing zero or more {@link FRCallbackUrl FRCallbackUrls}.
+     */
+    public static OBCallbackUrlsResponse1 packageResponse(List<FRCallbackUrl> frCallbackUrls, OBVersion apiVersion) {
+        FRCallbackUrl frCallbackUrl = !frCallbackUrls.isEmpty() ? frCallbackUrls.get(0) : null;
+        List<OBCallbackUrlResponseData1> filteredUrls = frCallbackUrls.stream()
+                .filter(it -> isAccessToResourceAllowed(apiVersion, OBVersion.fromString(it.getCallbackUrl().getVersion())))
+                .map(EventApiResponseUtil::toOBCallbackUrlResponseData1)
+                .collect(Collectors.toList());
+        return new OBCallbackUrlsResponse1()
+                .data(new OBCallbackUrlsResponseData1().callbackUrl(filteredUrls))
+                .meta(hasMetaSection(apiVersion) ? new Meta() : null)
+                .links(hasMetaSection(apiVersion) ? toSelfLink(frCallbackUrl, apiVersion) : null);
+    }
+
+    /**
+     * Provides the required {@link OBCallbackUrlResponse1} for the callback API, containing "links" and "meta"
+     * depending on the API version.
+     *
+     * @param apiVersion The version of the API currently being invoked.
+     * @param frCallbackUrl The {@link FRCallbackUrl} containing the data for the response.
+     * @return the populated {@link OBCallbackUrlResponse1} response
+     */
+    public static OBCallbackUrlResponse1 packageResponse(FRCallbackUrl frCallbackUrl, OBVersion apiVersion) {
+        return new OBCallbackUrlResponse1()
+                .data(toOBCallbackUrlResponseData1(frCallbackUrl))
+                .meta(hasMetaSection(apiVersion) ? new Meta() : null)
+                .links(hasMetaSection(apiVersion) ? toSelfLink(frCallbackUrl, apiVersion) : null);
+    }
+
+    private static OBCallbackUrlResponseData1 toOBCallbackUrlResponseData1(FRCallbackUrl frCallbackUrl) {
+        final FRCallbackUrlData data = frCallbackUrl.getCallbackUrl();
+        return new OBCallbackUrlResponseData1()
+                .callbackUrlId(frCallbackUrl.getId())
+                .url(data.getUrl())
+                .version(data.getVersion());
+    }
+
+    private static Links toSelfLink(FRCallbackUrl frCallbackUrl, OBVersion obVersion) {
+        // TODO - fix this as part of #55
+        return new Links();
+        //return resourceLinkService.toSelfLink(frCallbackUrl, discovery -> discovery.getVersion(version).getGetCallbackUrls());
+    }
+
+    private static boolean hasMetaSection(OBVersion apiVersion) {
+        return apiVersion != null && !apiVersion.equals(v3_0);
+    }
+}

--- a/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/persistence/document/event/FRCallbackUrl.java
+++ b/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/persistence/document/event/FRCallbackUrl.java
@@ -37,21 +37,22 @@ public class FRCallbackUrl implements Persistable<String> {
 
     @Id
     @Indexed
-    public String id;
+    private String id;
 
-    public FRCallbackUrlData callbackUrl;
+    private FRCallbackUrlData callbackUrl;
 
     @Indexed
-    public String tppId;
+    private String tppId;
 
     @CreatedDate
-    public DateTime created;
+    private DateTime created;
+
     @LastModifiedDate
-    public DateTime updated;
+    private DateTime updated;
 
     @Override
     public boolean isNew() {
-        return created == null;
+        return id == null;
     }
 
     public String getCallBackUrlString() {

--- a/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/persistence/document/event/FREventNotification.java
+++ b/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/persistence/document/event/FREventNotification.java
@@ -43,26 +43,26 @@ public class FREventNotification implements Persistable<String> {
 
     @Id
     @Indexed
-    public String id;
+    private String id;
 
     @Indexed
-    public String jti;
+    private String jti;
 
-    public String signedJwt;
+    private String signedJwt;
 
     @Indexed
-    public String tppId;
+    private String tppId;
 
     @CreatedDate
-    public DateTime created;
+    private DateTime created;
     @LastModifiedDate
-    public DateTime updated;
+    private DateTime updated;
 
-    public FREventPollingError errors;
+    private FREventPollingError errors;
 
     @Override
     public boolean isNew() {
-        return created == null;
+        return id == null;
     }
 
     public boolean hasErrors() {

--- a/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/persistence/document/event/FREventSubscription.java
+++ b/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/persistence/document/event/FREventSubscription.java
@@ -38,22 +38,22 @@ public class FREventSubscription implements Persistable<String> {
 
     @Id
     @Indexed
-    public String id;
+    private String id;
 
-    public FREventSubscriptionData eventSubscription;
+    private FREventSubscriptionData eventSubscription;
 
     @Indexed
-    public String tppId;
+    private String tppId;
 
     @CreatedDate
-    public DateTime created;
+    private DateTime created;
     @LastModifiedDate
-    public DateTime updated;
+    private DateTime updated;
 
-    public OBVersion version;
+    private OBVersion version;
 
     @Override
     public boolean isNew() {
-        return created == null;
+        return id == null;
     }
 }

--- a/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/validator/EventApiValidator.java
+++ b/securebanking-openbanking-uk-rs-simulator/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/validator/EventApiValidator.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright © 2020 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.securebanking.openbanking.uk.rs.validator;
+
+import com.forgerock.securebanking.openbanking.uk.error.OBErrorException;
+import com.forgerock.securebanking.openbanking.uk.error.OBRIErrorType;
+import com.google.common.base.Preconditions;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.util.StringUtils;
+import uk.org.openbanking.datamodel.event.OBEventSubscription1;
+import uk.org.openbanking.datamodel.event.OBEventSubscriptionResponse1;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.regex.Pattern;
+
+@Slf4j
+public class EventApiValidator {
+
+    public static void verifyValidCallbackUrl(final OBEventSubscriptionResponse1 obEventSubscription) throws OBErrorException {
+        Preconditions.checkNotNull(obEventSubscription, "There should not be a null request body here");
+        verifyValidCallbackUrl(obEventSubscription.getData().getCallbackUrl());
+    }
+
+    public static void verifyValidCallbackUrl(final OBEventSubscription1 obEventSubscription) throws OBErrorException {
+        Preconditions.checkNotNull(obEventSubscription, "There should not be a null request body here");
+        verifyValidCallbackUrl(obEventSubscription.getData().getCallbackUrl());
+    }
+
+    public static void verifyValidCallbackUrl(final String callbackUrl) throws OBErrorException {
+        // It is valid to not use a callback URL here as TPP may be using polling only. But, if submitted, callback URL must be valid.
+        if (!StringUtils.isEmpty(callbackUrl)) {
+            try {
+                // Will throw exception is bad URL
+                new URL(callbackUrl);
+
+                // Already checked URL above so just check path must end /<OB_Version>/event-subscriptions
+                String regex = "[^\\s]+\\/(v(\\d+\\.)?(\\d+\\.)?(\\*|\\d+))\\/event-notifications$";
+                boolean matches = Pattern.matches(regex, callbackUrl);
+                if (!matches) {
+                    log.debug("Event subscription callback URL must end with /{OB_VERSION>/event-notifications (e.g. /v3.1.1/). Submitted callback: was '{}'", callbackUrl);
+                    throw new OBErrorException(OBRIErrorType.INVALID_CALLBACK_URL, callbackUrl);
+                }
+            } catch (MalformedURLException e) {
+                log.debug("Event subscription callback URL is malformed. Submitted callback: was '{}'", callbackUrl, e);
+                throw new OBErrorException(OBRIErrorType.INVALID_CALLBACK_URL, callbackUrl);
+            }
+        }
+    }
+}

--- a/securebanking-openbanking-uk-rs-simulator/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/event/v3_1_2/callbackurl/CallbackUrlsApiControllerTest.java
+++ b/securebanking-openbanking-uk-rs-simulator/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/event/v3_1_2/callbackurl/CallbackUrlsApiControllerTest.java
@@ -1,0 +1,181 @@
+/**
+ * Copyright © 2020 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.securebanking.openbanking.uk.rs.api.obie.event.v3_1_2.callbackurl;
+
+import com.forgerock.securebanking.openbanking.uk.rs.persistence.document.event.FRCallbackUrl;
+import com.forgerock.securebanking.openbanking.uk.rs.persistence.repository.events.CallbackUrlsRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import uk.org.openbanking.datamodel.event.*;
+
+import java.util.List;
+import java.util.UUID;
+
+import static com.forgerock.securebanking.openbanking.uk.common.api.meta.OBVersion.v3_0;
+import static com.forgerock.securebanking.openbanking.uk.common.api.meta.OBVersion.v3_1_2;
+import static com.forgerock.securebanking.openbanking.uk.rs.testsupport.api.HttpHeadersTestDataFactory.requiredEventHttpHeaders;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+import static org.springframework.http.HttpMethod.*;
+import static org.springframework.http.HttpStatus.*;
+
+/**
+ * A SpringBoot test for the {@link CallbackUrlsApiController}.
+ */
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+public class CallbackUrlsApiControllerTest {
+
+    private static final String BASE_URL = "http://localhost:";
+    private static final String CALLBACK_URI = "/open-banking/v3.1.2/callback-urls";
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private CallbackUrlsRepository callbackUrlsRepository;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @AfterEach
+    void removeData() {
+        callbackUrlsRepository.deleteAll();
+    }
+
+    @Test
+    public void shouldCreateCallbackUrl() {
+        // Given
+        OBCallbackUrl1 obCallbackUrl1 = aValidOBCallbackUrl1();
+        String tppId = UUID.randomUUID().toString();
+        HttpEntity<OBCallbackUrl1> request = new HttpEntity<>(obCallbackUrl1, requiredEventHttpHeaders(callbacksUrl(), tppId));
+
+        // When
+        ResponseEntity<OBCallbackUrlResponse1> response = restTemplate.postForEntity(callbacksUrl(), request, OBCallbackUrlResponse1.class);
+
+        // Then
+        assertThat(response.getStatusCode()).isEqualTo(CREATED);
+        OBCallbackUrlResponseData1 responseData = response.getBody().getData();
+        assertThat(responseData.getCallbackUrlId()).isNotNull();
+        assertThat(responseData.getUrl()).isEqualTo(obCallbackUrl1.getData().getUrl());
+        assertThat(responseData.getVersion()).isEqualTo(obCallbackUrl1.getData().getVersion());
+        assertThat(response.getBody().getMeta()).isNotNull();
+        // TODO - enable as part of #54
+        //assertThat(response.getBody().getLinks().getFirst().equals(callbacksUrl()));
+    }
+
+    @Test
+    public void shouldReadCallBackUrls() {
+        // Given
+        OBCallbackUrl1 obCallbackUrl1 = aValidOBCallbackUrl1();
+        String callbacksUrl = callbacksUrl();
+        HttpHeaders headers = requiredEventHttpHeaders(callbacksUrl, UUID.randomUUID().toString());
+        HttpEntity<OBCallbackUrl1> request = new HttpEntity<>(obCallbackUrl1, headers);
+        ResponseEntity<OBCallbackUrlResponse1> persistedCallback = restTemplate.postForEntity(callbacksUrl, request, OBCallbackUrlResponse1.class);
+
+        // When
+        ResponseEntity<OBCallbackUrlsResponse1> response = restTemplate.exchange(callbacksUrl, GET, new HttpEntity<>(headers), OBCallbackUrlsResponse1.class);
+
+        // Then
+        assertThat(response.getStatusCode()).isEqualTo(OK);
+        assertThat(response.getBody().getData().getCallbackUrl()).isNotEmpty();
+        OBCallbackUrlResponseData1 callbackUrlResponse = response.getBody().getData().getCallbackUrl().get(0);
+        assertThat(callbackUrlResponse.getCallbackUrlId()).isEqualTo(persistedCallback.getBody().getData().getCallbackUrlId());
+        assertThat(callbackUrlResponse.getUrl()).isEqualTo(obCallbackUrl1.getData().getUrl());
+        assertThat(callbackUrlResponse.getVersion()).isEqualTo(obCallbackUrl1.getData().getVersion());
+        assertThat(response.getBody().getMeta()).isNotNull();
+        // TODO - enable as part of #54
+        //assertThat(response.getBody().getLinks().getFirst().equals(callbacksUrl));
+    }
+
+    @Test
+    public void shouldUpdateCallbackUrl() {
+        // Given
+        OBCallbackUrl1 obCallbackUrl1 = aValidOBCallbackUrl1();
+        HttpHeaders headers = requiredEventHttpHeaders(callbacksUrl(), UUID.randomUUID().toString());
+        HttpEntity<OBCallbackUrl1> createRequest = new HttpEntity<>(obCallbackUrl1, headers);
+        ResponseEntity<OBCallbackUrlResponse1> persistedCallback = restTemplate.postForEntity(callbacksUrl(), createRequest, OBCallbackUrlResponse1.class);
+        String updatedCallbackUrl = "http://updatedcallbackurl.com";
+        obCallbackUrl1.getData().setUrl(updatedCallbackUrl);
+        HttpEntity<OBCallbackUrl1> updateRequest = new HttpEntity<>(obCallbackUrl1, headers);
+        String url = callbackIdUrl(persistedCallback.getBody().getData().getCallbackUrlId());
+
+        // When
+        ResponseEntity<OBCallbackUrlResponse1> response = restTemplate.exchange(url, PUT, updateRequest, OBCallbackUrlResponse1.class);
+
+        // Then
+        assertThat(response.getStatusCode()).isEqualTo(OK);
+        assertThat(response.getBody().getData().getUrl()).isEqualTo(updatedCallbackUrl);
+    }
+
+    @Test
+    public void shouldFailToUpdateCallbackUrlCreatedInFutureVersion() {
+        // Given
+        OBCallbackUrl1 obCallbackUrl1 = aValidOBCallbackUrl1();
+        HttpHeaders headers = requiredEventHttpHeaders(callbacksUrl(), UUID.randomUUID().toString());
+        HttpEntity<OBCallbackUrl1> createRequest = new HttpEntity<>(obCallbackUrl1, headers);
+        ResponseEntity<OBCallbackUrlResponse1> persistedCallback = restTemplate.postForEntity(callbacksUrl(), createRequest, OBCallbackUrlResponse1.class);
+        obCallbackUrl1.getData().setUrl("http://updatedcallbackurl.com");
+        obCallbackUrl1.getData().setVersion(v3_0.getCanonicalName());
+        HttpEntity<OBCallbackUrl1> updateRequest = new HttpEntity<>(obCallbackUrl1, headers);
+        String callbackUrlId = persistedCallback.getBody().getData().getCallbackUrlId();
+        String url = callbackIdUrl(callbackUrlId).replace(v3_1_2.getCanonicalName(), v3_0.getCanonicalName());
+
+        // When
+        ResponseEntity<String> response = restTemplate.exchange(url, PUT, updateRequest, String.class);
+
+        // Then
+        assertThat(response.getStatusCode()).isEqualTo(CONFLICT);
+        assertThat(response.getBody()).isEqualTo("Callback URL: '" + callbackUrlId + "' can't be updated via an older API version.");
+    }
+
+    @Test
+    public void shouldDeleteCallbackUrl() {
+        // Given
+        OBCallbackUrl1 obCallbackUrl1 = aValidOBCallbackUrl1();
+        HttpHeaders headers = requiredEventHttpHeaders(callbacksUrl(), UUID.randomUUID().toString());
+        HttpEntity<OBCallbackUrl1> request = new HttpEntity<>(obCallbackUrl1, headers);
+        ResponseEntity<OBCallbackUrlResponse1> persistedCallback = restTemplate.postForEntity(callbacksUrl(), request, OBCallbackUrlResponse1.class);
+        String deleteUrl = callbackIdUrl(persistedCallback.getBody().getData().getCallbackUrlId());
+
+        // When
+        restTemplate.exchange(deleteUrl, DELETE, new HttpEntity<>(headers), Void.class);
+
+        // Then
+        List<FRCallbackUrl> callbacks = callbackUrlsRepository.findAll();
+        assertThat(callbacks).isEmpty();
+    }
+
+    private String callbacksUrl() {
+        return BASE_URL + port + CALLBACK_URI;
+    }
+
+    private String callbackIdUrl(String id) {
+        return callbacksUrl() + "/" + id;
+    }
+
+    private OBCallbackUrl1 aValidOBCallbackUrl1() {
+        return new OBCallbackUrl1().data(new OBCallbackUrlData1()
+                .url("http://callbackurl.com")
+                .version(v3_1_2.getCanonicalName()));
+    }
+}

--- a/securebanking-openbanking-uk-rs-simulator/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/testsupport/api/HttpHeadersTestDataFactory.java
+++ b/securebanking-openbanking-uk-rs-simulator/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/testsupport/api/HttpHeadersTestDataFactory.java
@@ -49,6 +49,7 @@ public class HttpHeadersTestDataFactory {
         headers.setBearerAuth("dummyAuthToken");
         headers.add("x-fapi-financial-id", UUID.randomUUID().toString());
         headers.add("x-idempotency-key", UUID.randomUUID().toString());
+        headers.add("x-fapi-interaction-id", UUID.randomUUID().toString());
         headers.add("x-ob-url", resourceUrl);
         headers.add("x-ob-permissions", ALL_NON_BASIC_PERMISSIONS);
         headers.add("x-ob-account-ids", accountId);
@@ -64,9 +65,29 @@ public class HttpHeadersTestDataFactory {
         headers.setContentType(MediaType.APPLICATION_JSON);
         headers.setBearerAuth("dummyAuthToken");
         headers.add("x-fapi-financial-id", UUID.randomUUID().toString());
+        headers.add("x-fapi-interaction-id", UUID.randomUUID().toString());
         headers.add("x-idempotency-key", UUID.randomUUID().toString());
         headers.add("x-jws-signature", "dummyJwsSignature");
         headers.add("x-ob-account-id", UUID.randomUUID().toString());
+        return headers;
+    }
+
+    /**
+     * Provides an instance of {@link HttpHeaders} with the minimal set of required headers for the Events API.
+     *
+     * @param resourceUrl The URL to retrieve the resource in question.
+     * @param tppId The ID of the TPP in question.
+     * @return the {@link HttpHeaders} instance.
+     */
+    public static HttpHeaders requiredEventHttpHeaders(String resourceUrl, String tppId) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(singletonList(MediaType.APPLICATION_JSON));
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setBearerAuth("dummyAuthToken");
+        headers.add("x-fapi-financial-id", UUID.randomUUID().toString());
+        headers.add("x-fapi-interaction-id", UUID.randomUUID().toString());
+        headers.add("x-ob-tpp-id", tppId);
+        headers.add("x-ob-url", resourceUrl);
         return headers;
     }
 }


### PR DESCRIPTION
### Callback URLs API controllers

- Tidied up controllers (e.g. constructor injection, removed annotations that are specified in the API interfaces)
- Removed TPP lookup related code
- Re-wrote `EventApiResponseUtil` () - using `getVersionFromPath()` instead of requiring OBVersion to be provided to its constructor (makes extending previous versions of controllers easier and less error prone).
- Made error handling consistent - throwing `OBErrorResponseException` in all versions
- Added Spring Integration tests

Issue: https://github.com/SecureBankingAcceleratorToolkit/SecureBankingAcceleratorToolkit/issues/51