### PR TITLE
5 - Fix for Discovery endpoint definition to appear in the swagger spec

### DIFF
--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/discovery/AvailableApiEndpoint.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/discovery/AvailableApiEndpoint.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.forgerock.securebanking.openbanking.uk.rs.discovery;
+package com.forgerock.securebanking.openbanking.uk.rs.api.discovery;
 
 import com.forgerock.securebanking.openbanking.uk.rs.common.OBApiReference;
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.OBGroupName;

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/discovery/AvailableApiEndpointsResolver.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/discovery/AvailableApiEndpointsResolver.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.forgerock.securebanking.openbanking.uk.rs.discovery;
+package com.forgerock.securebanking.openbanking.uk.rs.api.discovery;
 
 import com.forgerock.securebanking.openbanking.uk.rs.common.OBApiReference;
 import org.springframework.beans.factory.annotation.Value;

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/discovery/ControllerEndpointBlacklistHandler.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/discovery/ControllerEndpointBlacklistHandler.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.forgerock.securebanking.openbanking.uk.rs.discovery;
+package com.forgerock.securebanking.openbanking.uk.rs.api.discovery;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/discovery/ControllerMethod.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/discovery/ControllerMethod.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.forgerock.securebanking.openbanking.uk.rs.discovery;
+package com.forgerock.securebanking.openbanking.uk.rs.api.discovery;
 
 import lombok.Value;
 

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/discovery/DiscoveryApiConfigurationProperties.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/discovery/DiscoveryApiConfigurationProperties.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.forgerock.securebanking.openbanking.uk.rs.discovery;
+package com.forgerock.securebanking.openbanking.uk.rs.api.discovery;
 
 import com.forgerock.securebanking.openbanking.uk.rs.common.OBApiReference;
 import lombok.Data;

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/discovery/DiscoveryApiService.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/discovery/DiscoveryApiService.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.forgerock.securebanking.openbanking.uk.rs.discovery;
+package com.forgerock.securebanking.openbanking.uk.rs.api.discovery;
 
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.OBGroupName;
 import com.forgerock.securebanking.openbanking.uk.rs.common.OBApiReference;
@@ -35,16 +35,16 @@ import java.util.Map;
 @Slf4j
 public class DiscoveryApiService {
 
-    private final com.forgerock.securebanking.openbanking.uk.rs.discovery.DiscoveryApiConfigurationProperties discoveryProperties;
+    private final com.forgerock.securebanking.openbanking.uk.rs.api.discovery.DiscoveryApiConfigurationProperties discoveryProperties;
 
-    private final com.forgerock.securebanking.openbanking.uk.rs.discovery.AvailableApiEndpointsResolver availableApiEndpointsResolver;
+    private final com.forgerock.securebanking.openbanking.uk.rs.api.discovery.AvailableApiEndpointsResolver availableApiEndpointsResolver;
 
     private final ControllerEndpointBlacklistHandler blacklistHandler;
 
     private final Map<OBGroupName, Map<String, OBDiscoveryAPI>> discoveryApis = new HashMap<>();
 
-    public DiscoveryApiService(com.forgerock.securebanking.openbanking.uk.rs.discovery.DiscoveryApiConfigurationProperties discoveryProperties,
-                               com.forgerock.securebanking.openbanking.uk.rs.discovery.AvailableApiEndpointsResolver availableApiEndpointsResolver,
+    public DiscoveryApiService(com.forgerock.securebanking.openbanking.uk.rs.api.discovery.DiscoveryApiConfigurationProperties discoveryProperties,
+                               com.forgerock.securebanking.openbanking.uk.rs.api.discovery.AvailableApiEndpointsResolver availableApiEndpointsResolver,
                                ControllerEndpointBlacklistHandler blacklistHandler) {
         this.discoveryProperties = discoveryProperties;
         this.availableApiEndpointsResolver = availableApiEndpointsResolver;
@@ -57,10 +57,10 @@ public class DiscoveryApiService {
      */
     @PostConstruct
     protected void init() {
-        List<com.forgerock.securebanking.openbanking.uk.rs.discovery.AvailableApiEndpoint> availableEndpoints = availableApiEndpointsResolver.getAvailableApiEndpoints();
+        List<com.forgerock.securebanking.openbanking.uk.rs.api.discovery.AvailableApiEndpoint> availableEndpoints = availableApiEndpointsResolver.getAvailableApiEndpoints();
 
         // iterate over each API endpoint
-        for (com.forgerock.securebanking.openbanking.uk.rs.discovery.AvailableApiEndpoint availableEndpoint : availableEndpoints) {
+        for (com.forgerock.securebanking.openbanking.uk.rs.api.discovery.AvailableApiEndpoint availableEndpoint : availableEndpoints) {
             String version = availableEndpoint.getVersion();
             OBApiReference endpointReference = availableEndpoint.getApiReference();
             String endpointUrl = availableEndpoint.getUrl();

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/discovery/DiscoveryController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/discovery/DiscoveryController.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.forgerock.securebanking.openbanking.uk.rs.discovery;
+package com.forgerock.securebanking.openbanking.uk.rs.api.discovery;
 
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.OBGroupName;
 import io.swagger.annotations.Api;

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/configuration/SwaggerDocumentationConfig.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/configuration/SwaggerDocumentationConfig.java
@@ -15,8 +15,6 @@
  */
 package com.forgerock.securebanking.openbanking.uk.rs.configuration;
 
-import com.forgerock.securebanking.openbanking.uk.rs.discovery.DiscoveryApiService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -25,22 +23,15 @@ import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.service.ApiInfo;
 import springfox.documentation.service.Contact;
-import springfox.documentation.spi.DocumentationType;
-import springfox.documentation.spring.web.plugins.ApiSelectorBuilder;
 import springfox.documentation.spring.web.plugins.Docket;
-import uk.org.openbanking.datamodel.discovery.GenericOBDiscoveryAPILinks;
-import uk.org.openbanking.datamodel.discovery.OBDiscoveryAPI;
 
 import java.security.Principal;
-import java.util.Map;
 
 import static springfox.documentation.builders.PathSelectors.any;
-
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-10-11T14:17:28.882Z")
+import static springfox.documentation.spi.DocumentationType.SWAGGER_2;
 
 /**
- * Configuration class for the application's Swagger specification. Refer to the project's README.md for more
- * information.
+ * Configuration class for the application's Swagger specification.
  */
 @Configuration
 @PropertySource("classpath:messages/swagger.properties")
@@ -65,9 +56,6 @@ public class SwaggerDocumentationConfig {
     @Value("${swagger.contact.email}")
     public String swaggerContactEmail;
 
-    @Autowired
-    private DiscoveryApiService discoveryApiService;
-
     ApiInfo apiInfo() {
         return new ApiInfoBuilder()
                 .title(swaggerTitle)
@@ -80,26 +68,15 @@ public class SwaggerDocumentationConfig {
     }
 
     @Bean
-    public Docket customImplementation(@Value("${rs.baseUrl}") String baseUrl) {
-        ApiSelectorBuilder select = new Docket(DocumentationType.SWAGGER_2)
+    public Docket customImplementation() {
+        return new Docket(SWAGGER_2)
                 .ignoredParameterTypes(Principal.class)
                 .select()
-                .apis(RequestHandlerSelectors.basePackage("com.forgerock.securebanking.openbanking.uk.rs.api"));
-
-        for (Map<String, OBDiscoveryAPI> entry : discoveryApiService.getDiscoveryApis().values()) {
-            for (OBDiscoveryAPI obDiscoveryAPI : entry.values()) {
-                GenericOBDiscoveryAPILinks genericOBDiscoveryAPILinks = (GenericOBDiscoveryAPILinks) obDiscoveryAPI.getLinks();
-                genericOBDiscoveryAPILinks.getLinks().values()
-                        .forEach(link -> link.replaceFirst(baseUrl, ""));
-            }
-        }
-
-        return select
+                .apis(RequestHandlerSelectors.basePackage("com.forgerock.securebanking.openbanking.uk.rs.api"))
                 .paths(any())
                 .build()
                 .directModelSubstitute(org.joda.time.LocalDate.class, java.sql.Date.class)
                 .directModelSubstitute(org.joda.time.DateTime.class, java.util.Date.class)
                 .apiInfo(apiInfo());
     }
-
 }

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/web/DisabledEndpointInterceptor.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/web/DisabledEndpointInterceptor.java
@@ -15,8 +15,8 @@
  */
 package com.forgerock.securebanking.openbanking.uk.rs.web;
 
-import com.forgerock.securebanking.openbanking.uk.rs.discovery.ControllerEndpointBlacklistHandler;
-import com.forgerock.securebanking.openbanking.uk.rs.discovery.DiscoveryApiService;
+import com.forgerock.securebanking.openbanking.uk.rs.api.discovery.ControllerEndpointBlacklistHandler;
+import com.forgerock.securebanking.openbanking.uk.rs.api.discovery.DiscoveryApiService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.http.HttpStatus;

--- a/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/discovery/AvailableApiEndpointsResolverTest.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/discovery/AvailableApiEndpointsResolverTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.forgerock.securebanking.openbanking.uk.rs.discovery;
+package com.forgerock.securebanking.openbanking.uk.rs.api.discovery;
 
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.OBGroupName;
 import com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.v3_1_5.domesticpayments.DomesticPaymentsApiController;

--- a/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/discovery/ControllerEndpointBlacklistHandlerTest.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/discovery/ControllerEndpointBlacklistHandlerTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.forgerock.securebanking.openbanking.uk.rs.discovery;
+package com.forgerock.securebanking.openbanking.uk.rs.api.discovery;
 
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.OBVersion;
 import com.forgerock.securebanking.openbanking.uk.rs.persistence.repository.payments.DomesticPaymentSubmissionRepository;

--- a/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/discovery/DiscoveryApiServiceTest.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/discovery/DiscoveryApiServiceTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.forgerock.securebanking.openbanking.uk.rs.discovery;
+package com.forgerock.securebanking.openbanking.uk.rs.api.discovery;
 
 import com.forgerock.securebanking.openbanking.uk.rs.testsupport.discovery.AvailableApisTestDataFactory;
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.OBGroupName;

--- a/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/discovery/DiscoveryControllerTest.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/discovery/DiscoveryControllerTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.forgerock.securebanking.openbanking.uk.rs.discovery;
+package com.forgerock.securebanking.openbanking.uk.rs.api.discovery;
 
 import com.forgerock.securebanking.openbanking.uk.rs.common.OBApiReference;
 import org.junit.jupiter.api.Test;

--- a/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/testsupport/discovery/AvailableApisTestDataFactory.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/testsupport/discovery/AvailableApisTestDataFactory.java
@@ -17,7 +17,7 @@ package com.forgerock.securebanking.openbanking.uk.rs.testsupport.discovery;
 
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.OBGroupName;
 import com.forgerock.securebanking.openbanking.uk.rs.common.OBApiReference;
-import com.forgerock.securebanking.openbanking.uk.rs.discovery.AvailableApiEndpoint;
+import com.forgerock.securebanking.openbanking.uk.rs.api.discovery.AvailableApiEndpoint;
 import com.google.common.collect.ImmutableList;
 import org.apache.commons.lang3.tuple.Pair;
 


### PR DESCRIPTION
#### Fix for Discovery endpoint definition to appear in the swagger spec

Issue: https://github.com/SecureBankingAcceleratorToolkit/SecureBankingAcceleratorToolkit/issues/5