### PR TITLE
58 - Remove FRAccount complilation ambiguity

### DIFF
--- a/securebanking-openbanking-uk-rs-simulator-server/pom.xml
+++ b/securebanking-openbanking-uk-rs-simulator-server/pom.xml
@@ -106,10 +106,6 @@
             <artifactId>lombok</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk15on</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.modelmapper</groupId>
             <artifactId>modelmapper</artifactId>
         </dependency>

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/admin/data/DataUpdater.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/admin/data/DataUpdater.java
@@ -18,6 +18,7 @@ package com.forgerock.securebanking.openbanking.uk.rs.api.admin.data;
 import com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.account.*;
 import com.forgerock.securebanking.openbanking.uk.rs.api.admin.data.dto.FRAccountData;
 import com.forgerock.securebanking.openbanking.uk.rs.api.admin.data.dto.FRUserData;
+import com.forgerock.securebanking.openbanking.uk.rs.persistence.document.account.FRAccount;
 import com.forgerock.securebanking.openbanking.uk.rs.persistence.document.account.*;
 import com.forgerock.securebanking.openbanking.uk.rs.persistence.repository.accounts.accounts.FRAccountRepository;
 import com.forgerock.securebanking.openbanking.uk.rs.persistence.repository.accounts.balances.FRBalanceRepository;

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/admin/data/FakeDataApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/admin/data/FakeDataApiController.java
@@ -22,6 +22,7 @@ import com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.pay
 import com.forgerock.securebanking.openbanking.uk.error.OBErrorException;
 import com.forgerock.securebanking.openbanking.uk.rs.api.admin.data.dto.FRUserData;
 import com.forgerock.securebanking.openbanking.uk.rs.configuration.DataConfigurationProperties;
+import com.forgerock.securebanking.openbanking.uk.rs.persistence.document.account.FRAccount;
 import com.forgerock.securebanking.openbanking.uk.rs.persistence.document.account.*;
 import com.forgerock.securebanking.openbanking.uk.rs.persistence.repository.accounts.accounts.FRAccountRepository;
 import com.forgerock.securebanking.openbanking.uk.rs.persistence.repository.accounts.balances.FRBalanceRepository;


### PR DESCRIPTION
Compilation fix due to `FRAccount` ambiguity

- Required after a new `FRAccount` object was added to `securebanking-openbanking-uk-forgerock-datamodel` (for data transfer rather than storage)

**Issue**: https://github.com/SecureBankingAcceleratorToolkit/SecureBankingAcceleratorToolkit/issues/58