### PR TITLE
58 - Removed FRBankAccount and renamed FRAccountWithBalance

### DIFF
--- a/securebanking-openbanking-uk-rs-backoffice-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/account/AccountsApi.java
+++ b/securebanking-openbanking-uk-rs-backoffice-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/account/AccountsApi.java
@@ -20,7 +20,7 @@
  */
 package com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.account;
 
-import com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.account.FRBankAccountWithBalance;
+import com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.account.FRAccountWithBalance;
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -42,14 +42,14 @@ public interface AccountsApi {
      *
      * @param userId The ID of the user who owns the account
      * @param withBalance Indicates if the account's balances(s) should be returned. Defaults to false.
-     * @return a {@link List} of {@link FRBankAccountWithBalance} instances, or an empty list.
+     * @return a {@link List} of {@link FRAccountWithBalance} instances, or an empty list.
      */
     @ApiOperation(value = "Get User Accounts With Balance",
             nickname = "getUserAccountsWithBalance",
-            notes = "", response = FRBankAccountWithBalance.class,
+            notes = "", response = FRAccountWithBalance.class,
             tags = {"Get User Accounts With Balance",})
     @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "User Accounts With Balance", response = FRBankAccountWithBalance.class),
+            @ApiResponse(code = 200, message = "User Accounts With Balance", response = FRAccountWithBalance.class),
             @ApiResponse(code = 400, message = "Bad request", response = OBErrorResponse1.class),
             @ApiResponse(code = 401, message = "Unauthorized"),
             @ApiResponse(code = 403, message = "Forbidden", response = OBErrorResponse1.class),
@@ -61,7 +61,7 @@ public interface AccountsApi {
     @RequestMapping(value = "/search/findByUserId",
             produces = {"application/json; charset=utf-8"},
             method = RequestMethod.GET)
-    ResponseEntity<List<FRBankAccountWithBalance>> getUserAccountsWithBalance(
+    ResponseEntity<List<FRAccountWithBalance>> getUserAccountsWithBalance(
             @ApiParam(value = "The ID of the PSU who owns the account.")
             @RequestParam(value = "userId") String userId,
             @ApiParam(value = "Indicates if the account's balance(s) should be returned. Defaults to false.")

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/account/AccountsApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/account/AccountsApiController.java
@@ -15,8 +15,7 @@
  */
 package com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.account;
 
-import com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.account.FRBankAccount;
-import com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.account.FRBankAccountWithBalance;
+import com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.account.FRAccountWithBalance;
 import com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.account.FRCashBalance;
 import com.forgerock.securebanking.openbanking.uk.rs.persistence.document.account.FRAccount;
 import com.forgerock.securebanking.openbanking.uk.rs.persistence.document.account.FRBalance;
@@ -47,14 +46,14 @@ public class AccountsApiController implements AccountsApi {
     }
 
     @Override
-    public ResponseEntity<List<FRBankAccountWithBalance>> getUserAccountsWithBalance(String userId, boolean withBalance) {
+    public ResponseEntity<List<FRAccountWithBalance>> getUserAccountsWithBalance(String userId, boolean withBalance) {
         log.info("Read all accounts for user ID '{}', with Balances: {}", userId, withBalance);
         Collection<FRAccount> accountsByUserID = accountsRepository.findByUserID(userId);
 
         if (!withBalance || accountsByUserID.isEmpty()) {
             log.debug("No balances required so returning {} accounts for userId: {}", accountsByUserID.size(), userId);
             return ResponseEntity.ok(accountsByUserID.stream()
-                    .map(account -> toFRBankAccountWithBalance(account, emptyMap()))
+                    .map(account -> toFRAccountWithBalance(account, emptyMap()))
                     .collect(toList()));
         }
 
@@ -71,24 +70,24 @@ public class AccountsApiController implements AccountsApi {
         log.debug("Balances by accountId: {}", balancesByAccountId);
 
         return ResponseEntity.ok(accountsByUserID.stream()
-                .map(account -> toFRBankAccountWithBalance(account, balancesByAccountId))
+                .map(account -> toFRAccountWithBalance(account, balancesByAccountId))
                 .collect(toList())
         );
 
     }
 
-    private FRBankAccountWithBalance toFRBankAccountWithBalance(FRAccount account, Map<String, List<FRBalance>> balanceMap) {
+    private FRAccountWithBalance toFRAccountWithBalance(FRAccount account, Map<String, List<FRBalance>> balanceMap) {
         List<FRCashBalance> balances = Optional.ofNullable(balanceMap.get(account.getId()))
                 .orElse(emptyList())
                 .stream()
                 .map(FRBalance::getBalance)
                 .collect(toList());
 
-        return new FRBankAccountWithBalance(toFRBankAccount(account), balances);
+        return new FRAccountWithBalance(toFRAccountDto(account), balances);
     }
 
-    private FRBankAccount toFRBankAccount(FRAccount account) {
-        return account == null ? null : FRBankAccount.builder()
+    private com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.account.FRAccount toFRAccountDto(FRAccount account) {
+        return account == null ? null : com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.account.FRAccount.builder()
                 .id(account.getId())
                 .userId(account.getUserID())
                 .account(account.getAccount())

--- a/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/account/AccountsApiControllerTest.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/account/AccountsApiControllerTest.java
@@ -16,7 +16,7 @@
 package com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.account;
 
 import com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.account.FRBalanceType;
-import com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.account.FRBankAccountWithBalance;
+import com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.account.FRAccountWithBalance;
 import com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.account.FRCashBalance;
 import com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.account.FRCreditDebitIndicator;
 import com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.payment.FRAmount;
@@ -77,11 +77,11 @@ public class AccountsApiControllerTest {
         FRBalance accountBalance = aValidFRBalance(account.getId());
         frBalanceRepository.save(accountBalance);
         URI uri = findUserAccountsUriWithBalance(account.getUserID());
-        ParameterizedTypeReference<List<FRBankAccountWithBalance>> typeReference = new ParameterizedTypeReference<>() {
+        ParameterizedTypeReference<List<FRAccountWithBalance>> typeReference = new ParameterizedTypeReference<>() {
         };
 
         // When
-        ResponseEntity<List<FRBankAccountWithBalance>> response = restTemplate.exchange(
+        ResponseEntity<List<FRAccountWithBalance>> response = restTemplate.exchange(
                 uri,
                 HttpMethod.GET,
                 new HttpEntity<>(httpHeaders()),
@@ -90,7 +90,7 @@ public class AccountsApiControllerTest {
         // Then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).isNotEmpty();
-        FRBankAccountWithBalance accountWithBalance = response.getBody().get(0);
+        FRAccountWithBalance accountWithBalance = response.getBody().get(0);
         assertThat(accountWithBalance.getId()).isEqualTo(account.getId());
         assertThat(accountWithBalance.getUserId()).isEqualTo(account.getUserID());
         assertThat(accountWithBalance.getAccount().getAccountId()).isEqualTo(account.getAccount().getAccountId());
@@ -106,11 +106,11 @@ public class AccountsApiControllerTest {
         FRBalance accountBalance = aValidFRBalance(account.getId());
         frBalanceRepository.save(accountBalance);
         URI uri = findUserAccountsUri(account.getUserID(), false);
-        ParameterizedTypeReference<List<FRBankAccountWithBalance>> typeReference = new ParameterizedTypeReference<>() {
+        ParameterizedTypeReference<List<FRAccountWithBalance>> typeReference = new ParameterizedTypeReference<>() {
         };
 
         // When
-        ResponseEntity<List<FRBankAccountWithBalance>> response = restTemplate.exchange(
+        ResponseEntity<List<FRAccountWithBalance>> response = restTemplate.exchange(
                 uri,
                 HttpMethod.GET,
                 new HttpEntity<>(httpHeaders()),
@@ -119,7 +119,7 @@ public class AccountsApiControllerTest {
         // Then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).isNotEmpty();
-        FRBankAccountWithBalance accountWithBalance = response.getBody().get(0);
+        FRAccountWithBalance accountWithBalance = response.getBody().get(0);
         assertThat(accountWithBalance.getId()).isEqualTo(account.getId());
         assertThat(accountWithBalance.getBalances()).isEmpty();
     }
@@ -132,11 +132,11 @@ public class AccountsApiControllerTest {
         FRBalance accountBalance = aValidFRBalance(account.getId());
         frBalanceRepository.save(accountBalance);
         URI uri = findUserAccountsUri("unknown-user-id", false);
-        ParameterizedTypeReference<List<FRBankAccountWithBalance>> typeReference = new ParameterizedTypeReference<>() {
+        ParameterizedTypeReference<List<FRAccountWithBalance>> typeReference = new ParameterizedTypeReference<>() {
         };
 
         // When
-        ResponseEntity<List<FRBankAccountWithBalance>> response = restTemplate.exchange(
+        ResponseEntity<List<FRAccountWithBalance>> response = restTemplate.exchange(
                 uri,
                 HttpMethod.GET,
                 new HttpEntity<>(httpHeaders()),


### PR DESCRIPTION
Removed `FRBankAccount` and renamed `FRBankAccountWithBalance` to `FRAccountWithBalance`

Issue: https://github.com/SecureBankingAcceleratorToolkit/SecureBankingAcceleratorToolkit/issues/58