### PR TITLE
fix issues with k8s deployment

### DIFF
--- a/.github/workflows/merge-master.yml
+++ b/.github/workflows/merge-master.yml
@@ -44,16 +44,21 @@ jobs:
         run: |
           make docker repo=${{ secrets.RELEASE_REPO }}
 
+      - name: helm version
+        id: helm
+        run: |
+          HELM_VERSION=$(make version)
+          echo ::set-output name=version::"$HELM_VERSION"
+
       - name: package helm
         run: |
-          echo HELM_VERSION=$(make version) >> $GITHUB_ENV
-          make helm version=${{ env.HELM_VERSION }}
+          make helm version=${{ steps.helm.outputs.version }}
 
       - name: Publish Release Chart 
         id: upload
         uses: google-github-actions/upload-cloud-storage@main
         with:
-          path: ${{ env.SERVICE_NAME }}-${{ env.HELM_VERSION }}.tgz
+          path: ${{ env.SERVICE_NAME }}-${{ steps.helm.outputs.version }}.tgz
           destination: ${{ secrets.HELM_RELEASE_BUCKET }}/${{ env.SERVICE_NAME }}
 
       - uses: codecov/codecov-action@v1

--- a/_infra/helm/securebanking-openbanking-uk-rs/templates/deployment.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-rs/templates/deployment.yaml
@@ -51,12 +51,14 @@ spec:
             timeoutSeconds: 5
           env:
           - name: SPRING_DATA_MONGODB_HOST
-            value: "mongo"
+            value: "mongo-mongodb"
           - name: SERVER_PORT
             value: {{ .Values.deployment.server.port | quote }}
           - name: SPRING_CLOUD_CONFIG_URI
             value: "http://securebanking-spring-config-server:8080"
           - name: SPRING_PROFILES_ACTIVE
             value: "docker"
+          - name: RS_BASEURL
+            value: http://rs:8080
           resources:
             {{- toYaml .Values.deployment.resources | nindent 12 }}

--- a/_infra/helm/securebanking-openbanking-uk-rs/values.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-rs/values.yaml
@@ -25,10 +25,6 @@ ingress:
   additionalAnnotations:
     nginx.ingress.kubernetes.io/backend-protocol: HTTPS
     nginx.ingress.kubernetes.io/client-body-buffer-size: 1m
-    nginx.ingress.kubernetes.io/modsecurity-snippet: |
-      Include /etc/nginx/owasp-modsecurity-crs/nginx-modsecurity.conf
-      Include /etc/nginx/modsecurity/modsecurity.conf
-      SecRuleEngine On
     nginx.ingress.kubernetes.io/proxy-body-size: 150m
     nginx.ingress.kubernetes.io/proxy-buffer-size: 100k
 


### PR DESCRIPTION
There was an issue with the kubernetes deployment. some config was mismatching.
The merge GH actions was not tagging charts correctly, this has been fixed.
Delegate WAF config to external config for ease of development.